### PR TITLE
Override Nextflow params via optional params

### DIFF
--- a/run_nextflow_wgs.sh
+++ b/run_nextflow_wgs.sh
@@ -7,6 +7,7 @@ workflow_path='/hpc/diaggen/software/production/DxNextflowWGS'
 input=`realpath -e $1`
 output=`realpath $2`
 email=$3
+optional_params=( "${@:4}" )
 mkdir -p $output && cd $output
 mkdir -p log
 
@@ -35,7 +36,8 @@ module load Java/1.8.0_60
 --outdir $output \
 --email $email \
 -profile slurm \
--resume -ansi-log false
+-resume -ansi-log false \
+${optional_params[@]:-""}
 
 if [ \$? -eq 0 ]; then
     echo "Nextflow done."


### PR DESCRIPTION
### What has changed?

1. Possibility to override Nextflow parameters. 

Example of command:
`/hpc/diaggen/software/production/DxNextflowWGS/run_nextflow_wgs.sh /hpc/diaggen/data/raw/<machine>/<runID>/Data/Intensities/BaseCalls/<projectname_and_id> /hpc/diaggen/data/processed/genomes/<runID_projectid> bioinformatica-genetica@umcutrecht.nl "--exoncov_path /hpc/diaggen/software/development/ExonCov" "--freec_window 1200"`


### Additional information
Related: https://github.com/UMCUGenetics/DxNextflowWES/pull/51 

- Multiple parameters are allowed. I suspect the only limit is the number of characters allowed on the command line.
- A parameter is always a pair of the parameter key and value, should be between double quotes and space separated.
- Also possible to use other nextflow run options. Limitation: what is supported in Nextflow.
  - At the moment, providing process resources to override the config is not supported by Nextflow. If it was, or if default process resource is not part of config, you can provide it via: `-process.key=value`.  For more details/information, see [Azure PBI 109147](https://dev.azure.com/umcu/LAB-Bioinformatics-Genetics/_workitems/edit/109147 )
