### PR TITLE
Feature/publish hardlink

### DIFF
--- a/WGS.config
+++ b/WGS.config
@@ -45,7 +45,7 @@ process {
 
         publishDir {
             path = "$params.outdir/bam_files"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -89,7 +89,7 @@ process {
 
         publishDir {
             path = "$params.outdir/gvcf"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -112,7 +112,7 @@ process {
 
         publishDir {
             path = "$params.outdir"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -123,7 +123,7 @@ process {
 
         publishDir {
             path = "$params.outdir/fingerprint"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -140,7 +140,7 @@ process {
 
         publishDir {
             path = "$params.outdir/cnv/freec"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -151,7 +151,7 @@ process {
 
         publishDir {
             path = "$params.outdir/cnv/qdnaseq"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -162,7 +162,7 @@ process {
 
         publishDir {
             path = "$params.outdir/baf"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -173,7 +173,7 @@ process {
 
         publishDir {
             path = "$params.outdir/baf"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -185,7 +185,7 @@ process {
 
         publishDir {
             path = "$params.outdir/QC/FastQC"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -197,7 +197,7 @@ process {
 
         publishDir {
             path = "$params.outdir/QC/Picard"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -209,7 +209,7 @@ process {
 
         publishDir {
             path = "$params.outdir/QC/Picard"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -221,7 +221,7 @@ process {
 
         publishDir {
             path = "$params.outdir/QC/Picard"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -232,7 +232,7 @@ process {
 
         publishDir {
             path = "$params.outdir/QC"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -243,7 +243,7 @@ process {
 
         publishDir {
             path = "$params.outdir/log"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -254,7 +254,7 @@ process {
 
         publishDir {
             path = "$params.outdir/log"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 }


### PR DESCRIPTION
Set `publishDir` mode to `link` for all processes with a `publishDir` setting. 