### PR TITLE
Release/v1.3.0

### DIFF
--- a/WGS.config
+++ b/WGS.config
@@ -33,228 +33,250 @@ params {
 process {
     withLabel: BWA_0_7_17_Mem {
         cpus = 20
-        memory = '70G'
-        time = '6h'
+        memory = { 20.GB * task.attempt }
+        time = { (1.ms * fastq.sum{it.size()} / 900) * task.attempt }
     }
 
     withLabel: Sambamba_0_7_0_MarkdupMerge {
         cpus = 10
-        memory = '10G'
-        time = '2h'
-        clusterOptions = "$params.cluster_options --gres=tmpspace:20G"
+        memory = { 50.GB * task.attempt }
+        time = { (1.ms * bam_files.sum{it.size()} / 11000) * task.attempt }
+        clusterOptions = "$params.cluster_options --gres=tmpspace:100G"
 
         publishDir {
             path = "$params.outdir/bam_files"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: GATK_3_8_1_0_gf15c1c3ef_BaseRecalibrator {
         cpus = 4
-        memory = '16G'
-        time = '6h'
+        memory = { 32.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 4000) * task.attempt }
     }
 
     withLabel: Sambamba_0_7_0_ViewUnmapped {
         cpus = 2
-        memory = '1G'
-        time = '30m'
+        memory = { 1.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 45000) * task.attempt }
         clusterOptions = "$params.cluster_options --gres=tmpspace:10G"
     }
 
     withLabel: Sambamba_0_7_0_Merge {
         cpus = 10
-        memory = '10G'
-        time = '2h'
+        memory = { 10.GB * task.attempt }
+        time = { (1.ms * bam_files.sum{it.size()} / 20000) * task.attempt }
         clusterOptions = "$params.cluster_options --gres=tmpspace:10G"
     }
 
     withLabel: PICARD_2_22_0_IntervalListTools {
         cpus = 2
-        memory = '5G'
-        time = '5m'
+        memory = { 5.GB * task.attempt }
+        time = { 5.m * task.attempt }
         clusterOptions = "$params.cluster_options --gres=tmpspace:10G"
     }
 
     withLabel: GATK_3_8_1_0_gf15c1c3ef_HaplotypeCallerGVCF {
         cpus = 2
-        memory = '20G'
-        time = '2h'
+        memory = { 20.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 5500) * task.attempt }
     }
 
     withLabel: GATK_3_8_1_0_gf15c1c3ef_CatVariantsGVCF {
         cpus = 2
-        memory = '20G'
-        time = '2h'
+        memory = { 20.GB * task.attempt }
+        time = { (1.ms * gvcf_files.sum{it.size()} / 14000) * task.attempt }
 
         publishDir {
             path = "$params.outdir/gvcf"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: GATK_3_8_1_0_gf15c1c3ef_GenotypeGVCFs {
         cpus = 2
-        memory = '20G'
-        time = '2h'
+        memory = { 20.GB * task.attempt }
+        time = { (1.ms * gvcf_files.sum{it.size()} / 1500 + 1.m) * task.attempt }
     }
 
     withLabel: GATK_3_8_1_0_gf15c1c3ef_CombineVariants {
         cpus = 2
-        memory = '20G'
-        time = '1h'
+        memory = { 20.GB * task.attempt }
+        time = { (1.ms * vcf_files.sum{it.size()} / 2000) * task.attempt }
     }
 
     withLabel: GATK_3_8_1_0_gf15c1c3ef_VariantFiltrationSnpIndel {
         cpus = 2
-        memory = '20G'
-        time = '1h'
+        memory = { 20.GB * task.attempt }
+        time = { (1.ms * vcf_file.size() / 850) * task.attempt }
 
         publishDir {
             path = "$params.outdir"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withName: GATK_UnifiedGenotyper_Fingerprint {
         cpus = 2
-        memory = '5G'
-        time = '5m'
+        memory = { 5.GB * task.attempt }
+        time = { 5.m * task.attempt }
 
         publishDir {
             path = "$params.outdir/fingerprint"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: ExonCov {
         cpus = 4
-        memory = '8G'
-        time = '2h'
+        memory = { 20.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 24000) * task.attempt }
     }
 
-    withLabel: ControlFreec_11_5 {
+    withLabel: ControlFreec_11_5_Freec {
         cpus = 4
-        memory = '5G'
-        time = '2h'
+        memory = { 5.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 6000) * task.attempt }
 
         publishDir {
             path = "$params.outdir/cnv/freec"
-            mode = 'copy'
+            mode = 'link'
+        }
+    }
+
+    withLabel: ControlFreec_11_5_AssessSignificance {
+        cpus = 4
+        memory = { 5.GB * task.attempt }
+        time = { (1.s * cnv_file.size() / 2) * task.attempt }
+
+        publishDir {
+            path = "$params.outdir/cnv/freec"
+            mode = 'link'
+        }
+    }
+
+    withLabel: ControlFreec_11_5.makeGraph {
+        cpus = 4
+        memory = { 5.GB * task.attempt }
+        time = { (1.s * cnv_file.size() / 140) * task.attempt }
+
+        publishDir {
+            path = "$params.outdir/cnv/freec"
+            mode = 'link'
         }
     }
 
     withLabel: QDNAseq {
         cpus = 2
-        memory = '40G'
-        time = '4h'
+        memory = { 40.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 17000) * task.attempt }
 
         publishDir {
             path = "$params.outdir/cnv/qdnaseq"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withName: GATK_UnifiedGenotyper_BAF {
         cpus = 2
-        memory = '5G'
-        time = '2h'
+        memory = { 5.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 5300) * task.attempt }
 
         publishDir {
             path = "$params.outdir/baf"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: BAF {
         cpus = 2
-        memory = '8G'
-        time = '2h'
+        memory = { 8.GB * task.attempt }
+        time = { (1.ms * vcf_file.size() / 150) * task.attempt }
 
         publishDir {
             path = "$params.outdir/baf"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: FASTQC_0_11_8 {
         cpus = 2
-        memory = '1G'
-        time = '2h'
+        memory = { 1.GB * task.attempt }
+        time = { (1.ms * fastq[0].size() / 3000) * task.attempt }
         clusterOptions = "$params.cluster_options --gres=tmpspace:10G"
 
         publishDir {
             path = "$params.outdir/QC/FastQC"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: PICARD_2_22_0_CollectMultipleMetrics {
         cpus = 2
-        memory = '8G'
-        time = '4h'
+        memory = { 8.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 4000) * task.attempt }
         clusterOptions = "$params.cluster_options --gres=tmpspace:10G"
 
         publishDir {
             path = "$params.outdir/QC/Picard"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: PICARD_2_22_0_CollectWgsMetrics {
         cpus = 2
-        memory = '8G'
-        time = '6h'
+        memory = { 8.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 2500) * task.attempt }
         clusterOptions = "$params.cluster_options --gres=tmpspace:10G"
 
         publishDir {
             path = "$params.outdir/QC/Picard"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: PICARD_2_22_0_EstimateLibraryComplexity {
         cpus = 2
-        memory = '8G'
-        time = '4h'
+        memory = { 8.GB * task.attempt }
+        time = { (1.ms * bam_file.size() / 800) * task.attempt }
         clusterOptions = "$params.cluster_options --gres=tmpspace:100G"
 
         publishDir {
             path = "$params.outdir/QC/Picard"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: MultiQC_1_9 {
         cpus = 2
-        memory = '1G'
-        time = '5m'
+        memory = { 5.GB * task.attempt }
+        time = { 5.m * task.attempt }
 
         publishDir {
             path = "$params.outdir/QC"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: VersionLog {
         cpus = 2
-        memory = '5G'
-        time = '10m'
+        memory = { 5.GB * task.attempt }
+        time = { 5.m * task.attempt }
 
         publishDir {
             path = "$params.outdir/log"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
     withLabel: Workflow_Export_Params {
         cpus = 2
-        memory = '5G'
-        time = '10m'
+        memory = { 5.GB * task.attempt }
+        time = { 5.m * task.attempt }
 
         publishDir {
             path = "$params.outdir/log"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 }
@@ -284,7 +306,7 @@ profiles {
             clusterOptions = "$params.cluster_options"
 
             errorStrategy = 'retry'
-            maxRetries = 3
+            maxRetries = 1
         }
 
         singularity {

--- a/WGS.config
+++ b/WGS.config
@@ -155,7 +155,7 @@ process {
         }
     }
 
-    withLabel: ControlFreec_11_5.makeGraph {
+    withLabel: ControlFreec_11_5_makeGraph {
         cpus = 4
         memory = { 5.GB * task.attempt }
         time = { (1.s * cnv_file.size() / 140) * task.attempt }

--- a/run_nextflow_wgs.sh
+++ b/run_nextflow_wgs.sh
@@ -7,6 +7,7 @@ workflow_path='/hpc/diaggen/software/production/DxNextflowWGS'
 input=`realpath -e $1`
 output=`realpath $2`
 email=$3
+optional_params=( "${@:4}" )
 mkdir -p $output && cd $output
 mkdir -p log
 
@@ -35,7 +36,8 @@ module load Java/1.8.0_60
 --outdir $output \
 --email $email \
 -profile slurm \
--resume -ansi-log false
+-resume -ansi-log false \
+${optional_params[@]:-""}
 
 if [ \$? -eq 0 ]; then
     echo "Nextflow done."


### PR DESCRIPTION
Previously reviewed in #14 

Use dynamic compute resources for time and memory using task.attempt and filesize.
Similar feature in WES: https://github.com/UMCUGenetics/DxNextflowWES/pull/60

- Several run_projects are used to optimize constants. With current proposal, most processes complete with first attempt.
- We discussed whether tmp space could become dependent on file size or task attempt. Since it is not a default nextflow executor setting param, it is not.
- filesize is mainly used to determine current settings. If a single reference file is reflecting the required memory, a default value is used instead of ref file size.