### PR TITLE
v1.3.1 (hotfix)

### DIFF
--- a/WGS.config
+++ b/WGS.config
@@ -96,7 +96,7 @@ process {
     withLabel: GATK_3_8_1_0_gf15c1c3ef_GenotypeGVCFs {
         cpus = 2
         memory = { 20.GB * task.attempt }
-        time = { (1.ms * gvcf_files.sum{it.size()} / 1500 + 1.m) * task.attempt }
+        time = { 2.h * task.attempt }
     }
 
     withLabel: GATK_3_8_1_0_gf15c1c3ef_CombineVariants {


### PR DESCRIPTION
- Revert GenotypeGVCF, does not work with 1 or n files.